### PR TITLE
Fix environment check basic auth tests

### DIFF
--- a/code/EnvironmentChecker.php
+++ b/code/EnvironmentChecker.php
@@ -60,7 +60,13 @@ class EnvironmentChecker extends RequestHandler {
 	}
 
 	function canAccess($member = null, $permission = "ADMIN") {
-		if(!$member) $member = Member::currentUser();
+		if(!$member) {
+			$member = Member::currentUser();
+		}
+
+		if(!$member) {
+			$member = BasicAuth::requireLogin('Environment Checker', $permission, false);
+		}
 
 		// We allow access to this controller regardless of live-status or ADMIN permission only
 		// if on CLI.  Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.


### PR DESCRIPTION
Was assuming that Member::currentMember() is set,
which isn't the case unless you log in beforehand and start a PHP session.

Given we want the checks to run on their own without user interaction,
they need to work in isolation through a single HTTP call containing
the basic auth info.