### PR TITLE
Allow public access to the dev/health url and change response to 500

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -4,6 +4,6 @@ After: 'framework/*','cms/*'
 ---
 Director:
   rules:
-    'dev/health': 'DevHealthController'
+    'health/check': 'DevHealthController'
     'dev/check/$Suite': 'DevCheckController'
 

--- a/code/DevHealthController.php
+++ b/code/DevHealthController.php
@@ -19,8 +19,7 @@ class DevHealthController extends Controller
         // health check does not require permission to run
 
         $checker = new EnvironmentChecker('health', 'Site health');
-        $checker->init('');
-        $checker->setErrorCode(404);
+        $checker->setErrorCode(500);
 
         return $checker;
     }


### PR DESCRIPTION
According to the documentation, the dev/health route should be publically accessible, this PR removes the current permission check.

In addition to this, the default return error code is 500 (server error) instead of 404 (which is regarded as a client error).